### PR TITLE
redirect <no translation found> message to stderr

### DIFF
--- a/runki.go
+++ b/runki.go
@@ -170,7 +170,8 @@ func addCard(lang string, creds string, user string, pass string,
 
 		if lookup == nil {
 			if !silent {
-				fmt.Println("<" + unknown + ": no translation found>")
+				fmt.Fprintf(os.Stderr,
+					"<" + unknown + ": no translation found>")
 			}
 
 			continue


### PR DESCRIPTION
Sometimes, word cannot be translated via `Yandex.Dictionary`, but if I use runki in some binary, which do something like:
```
INPUT=$(input)
TRANSLATE=$(runki <<< "$INPUT")
notify-send "$TRANSLATE"
```
And if word cannot be translated, I can't know about this before showing notification, so I think it's wrong behaviour.

Probably, `os.Exit(1)` it's good solution, but runki can translate more than 1 word, so I think, redirect that messages to stderr it's better solution it this case.